### PR TITLE
Improve the Observer example

### DIFF
--- a/09-observer/lib/Observer.pm
+++ b/09-observer/lib/Observer.pm
@@ -1,9 +1,19 @@
 package Observer;
 
-use Moo;
+use Moo::Role;
 
-has 'subject' => (is => 'rw');
+requires 'update';
+has 'subject' => (is => 'rw', required => 1);
 
-sub update { }
+sub BUILD {
+    my ($self) = @_;
+
+    $self->subject->attach($self);
+}
+
+sub DEMOLISH {
+    my ($self) = @_;
+    $self->subject->detach($self);
+}
 
 1;

--- a/09-observer/lib/Observer/BinaryObserver.pm
+++ b/09-observer/lib/Observer/BinaryObserver.pm
@@ -1,15 +1,8 @@
 package Observer::BinaryObserver;
 
 use Moo;
-extends 'Observer';
 
-has 'subject' => (is => 'ro', required => 1);
-
-sub BUILD {
-    my ($self) = @_;
-
-    $self->subject->attach($self);
-}
+with 'Observer';
 
 sub update {
     my ($self) = @_;

--- a/09-observer/lib/Observer/HexaObserver.pm
+++ b/09-observer/lib/Observer/HexaObserver.pm
@@ -1,15 +1,8 @@
 package Observer::HexaObserver;
 
 use Moo;
-extends 'Observer';
 
-has 'subject' => (is => 'ro', required => 1);
-
-sub BUILD {
-    my ($self) = @_;
-
-    $self->subject->attach($self);
-}
+with 'Observer';
 
 sub update {
     my ($self) = @_;

--- a/09-observer/lib/Observer/OctalObserver.pm
+++ b/09-observer/lib/Observer/OctalObserver.pm
@@ -1,15 +1,8 @@
 package Observer::OctalObserver;
 
 use Moo;
-extends 'Observer';
 
-has 'subject' => (is => 'ro', required => 1);
-
-sub BUILD {
-    my ($self) = @_;
-
-    $self->subject->attach($self);
-}
+with 'Observer';
 
 sub update {
     my ($self) = @_;

--- a/09-observer/lib/Subject.pm
+++ b/09-observer/lib/Subject.pm
@@ -1,32 +1,51 @@
 package Subject;
 
 use Moo;
+use Scalar::Util qw( weaken );
 
 has 'state'     => (is => 'rw');
-has 'observers' => (is => 'rw');
+has 'observers' => (is => 'rw',
+                    clearer => 'clear_observers',
+                    default => sub { [] });
 
 sub setState {
     my ($self, $state) = @_;
 
-    $self->{state} = $state;
+    $self->state($state);
     $self->notifyObservers;
 }
 
 sub attach {
     my ($self, $observer) = @_;
 
-    push @{$self->{observers}}, $observer;
+    push @{$self->observers}, $observer;
+    weaken($self->observers->[-1]);
+}
+
+sub detach {
+    my ($self, $observer) = @_;
+    for my $index (0 .. $#{ $self->observers }) {
+        if ($self->observers->[$index] == $observer) {
+            splice @{ $self->observers }, $index, 1;
+            last;
+        }
+    }
 }
 
 sub notifyObservers {
     my ($self) = @_;
 
     my $res = [];
-    foreach my $observer (@{$self->{observers}}) {
+    foreach my $observer (@{$self->observers}) {
         push @$res, $observer->update;
     }
 
     return $res;
+}
+
+sub DEMOLISH {
+    my ($self) = @_;
+    $self->clear_observers;
 }
 
 1;

--- a/09-observer/t/unit-test.t
+++ b/09-observer/t/unit-test.t
@@ -11,9 +11,9 @@ use Observer::OctalObserver;
 use Observer::BinaryObserver;
 
 my $subject = Subject->new;
-Observer::HexaObserver->new({ subject => $subject });
-Observer::OctalObserver->new({ subject => $subject });
-Observer::BinaryObserver->new({ subject => $subject });
+my $hexO = Observer::HexaObserver->new({ subject => $subject });
+my $octO = Observer::OctalObserver->new({ subject => $subject });
+my $binO = Observer::BinaryObserver->new({ subject => $subject });
 
 my $tests = {
     14 => ['Hexa string: e.', 'Octal string: 16.','Binary string: 1110.' ],
@@ -23,5 +23,10 @@ my $tests = {
 foreach my $state (keys %$tests) {
     is_deeply($subject->setState($state), $tests->{$state});
 }
+
+# Test the weak links and detaching on destruction.
+undef $binO;
+undef $octO;
+is_deeply($subject->setState(11), ['Hexa string: b.']);
 
 done_testing();


### PR DESCRIPTION
Convert the Observer to a role. It shortens the code and is usually
better than abstract classes in Perl.

Make the observer links in Subject weak. Add a detach method to
subject and call it from the Observers' destructor. Don't acces
attributes as hash elements, use accessors.

Test the new behaviour.